### PR TITLE
Add author display toggle feature in site settings

### DIFF
--- a/app/controllers/admin/site_settings_controller.rb
+++ b/app/controllers/admin/site_settings_controller.rb
@@ -4,7 +4,8 @@ class Admin::SiteSettingsController < Admin::BaseController
       site_title: SiteSetting.site_title,
       default_og_image: SiteSetting.default_og_image,
       top_page_description: SiteSetting.top_page_description,
-      copyright: SiteSetting.copyright
+      copyright: SiteSetting.copyright,
+      author_display_enabled: SiteSetting.get("author_display_enabled", "true")
     }
   end
 
@@ -52,7 +53,7 @@ class Admin::SiteSettingsController < Admin::BaseController
   private
 
   def settings_params
-    params.require(:site_settings).permit(:site_title, :default_og_image, :top_page_description, :copyright)
+    params.require(:site_settings).permit(:site_title, :default_og_image, :top_page_description, :copyright, :author_display_enabled)
   end
 
   # フル著作権テキストから著作権者名だけを抽出

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -45,7 +45,7 @@ module ApplicationHelper
   end
 
   def show_author_info?
-    @_show_author_info ||= Article.published.select(:author).distinct.count >= 2
+    @_show_author_info ||= SiteSetting.author_display_enabled && Article.published.select(:author).distinct.count >= 2
   end
 
   # Article list helpers

--- a/app/models/site_setting.rb
+++ b/app/models/site_setting.rb
@@ -45,6 +45,10 @@ class SiteSetting < ApplicationRecord
     "© #{Date.current.year} #{copyright}. All rights reserved."
   end
 
+  def self.author_display_enabled
+    get("author_display_enabled", "true") == "true"
+  end
+
   private
 
   def allows_blank_value?

--- a/app/views/admin/site_settings/show.html.erb
+++ b/app/views/admin/site_settings/show.html.erb
@@ -85,6 +85,27 @@
       </div>
     </div>
 
+    <div>
+      <%= label_tag "site_settings[author_display_enabled]", "記事の著者表示", class: "block text-sm font-medium mb-1" %>
+      <div class="flex items-center space-x-4">
+        <label class="flex items-center">
+          <%= radio_button_tag "site_settings[author_display_enabled]", "true", 
+                               @settings[:author_display_enabled] == "true", 
+                               class: "mr-2 spec--author-display-enabled-true" %>
+          <span class="text-sm">表示する</span>
+        </label>
+        <label class="flex items-center">
+          <%= radio_button_tag "site_settings[author_display_enabled]", "false", 
+                               @settings[:author_display_enabled] == "false", 
+                               class: "mr-2 spec--author-display-enabled-false" %>
+          <span class="text-sm">表示しない</span>
+        </label>
+      </div>
+      <div class="text-xs text-gray-500 mt-1">
+        記事一覧や記事詳細ページで著者名を表示するかどうかを設定できます
+      </div>
+    </div>
+
     <div class="flex gap-4">
       <%= submit_tag "設定を保存", class: "a--button is-lg is-primary spec--save-button" %>
       <%= link_to "キャンセル", admin_articles_path, class: "a--button is-lg is-border-secondary spec--cancel-button" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -20,7 +20,7 @@
     <h1 class="text-5xl font-bold spec--article-title"><%= @article.title %></h1>
     <div class="flex items-center gap-4 text-sm text-gray-500 mb-4">
       <% if show_author_info? %>
-        <span><%= @article.author %></span>
+        <span class="spec--article-author"><%= @article.author %></span>
       <% end %>
       <span><%= format_date_with_weekday(@article.created_at) %></span>
     </div>

--- a/test/helpers/articles_helper_test.rb
+++ b/test/helpers/articles_helper_test.rb
@@ -6,6 +6,7 @@ class ArticlesHelperTest < ActionView::TestCase
   def setup
     Article.destroy_all
     Admin.destroy_all
+    SiteSetting.destroy_all
     
     @admin1 = Admin.create!(
       email: "admin1@example.com",
@@ -20,6 +21,9 @@ class ArticlesHelperTest < ActionView::TestCase
       password: "password123",
       password_confirmation: "password123"
     )
+    
+    # Default: author display enabled
+    SiteSetting.set("author_display_enabled", "true")
   end
 
   test "show_author_info? should return false when no published articles" do
@@ -116,5 +120,51 @@ class ArticlesHelperTest < ActionView::TestCase
     # We can't directly test memoization, but we can verify consistent behavior
     result2 = show_author_info?
     assert_equal result1, result2
+  end
+
+  test "show_author_info? should return false when author display is disabled" do
+    # Set author display to disabled
+    SiteSetting.set("author_display_enabled", "false")
+    
+    # Create multiple authors with published articles
+    Article.create!(
+      title: "Article by Author 1",
+      body: "Content",
+      author: @admin1.user_id,
+      draft: false
+    )
+    
+    Article.create!(
+      title: "Article by Author 2",
+      body: "Content",
+      author: @admin2.user_id,
+      draft: false
+    )
+    
+    # Should return false despite multiple authors because setting is disabled
+    assert_not show_author_info?
+  end
+
+  test "show_author_info? should return true when author display is enabled and multiple authors exist" do
+    # Set author display to enabled (should be default, but explicit for clarity)
+    SiteSetting.set("author_display_enabled", "true")
+    
+    # Create multiple authors with published articles
+    Article.create!(
+      title: "Article by Author 1",
+      body: "Content",
+      author: @admin1.user_id,
+      draft: false
+    )
+    
+    Article.create!(
+      title: "Article by Author 2",
+      body: "Content",
+      author: @admin2.user_id,
+      draft: false
+    )
+    
+    # Should return true because setting is enabled and multiple authors exist
+    assert show_author_info?
   end
 end

--- a/test/system/author_display_toggle_playwright_test.rb
+++ b/test/system/author_display_toggle_playwright_test.rb
@@ -1,0 +1,129 @@
+require "application_playwright_test_case"
+
+class AuthorDisplayTogglePlaywrightTest < ApplicationPlaywrightTestCase
+  def setup
+    super
+    
+    # Create test admins
+    @admin1 = Admin.create!(
+      email: "admin1@example.com",
+      user_id: "author1",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    
+    @admin2 = Admin.create!(
+      email: "admin2@example.com", 
+      user_id: "author2",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    
+    # Create articles by different authors
+    @article1 = Article.create!(
+      title: "Article by Author 1",
+      body: "Content by author 1",
+      author: @admin1.user_id,
+      draft: false
+    )
+    
+    @article2 = Article.create!(
+      title: "Article by Author 2",
+      body: "Content by author 2",
+      author: @admin2.user_id,
+      draft: false
+    )
+    
+    # Set initial state: author display enabled
+    SiteSetting.set("author_display_enabled", "true")
+  end
+
+  test "admin can toggle author display setting" do
+    login_as_admin
+
+    # Navigate to site settings
+    @page.goto("http://localhost:#{@server_port}/admin/site-settings")
+    @page.wait_for_selector("h1:has-text('サイト設定')")
+
+    # Check that author display is enabled by default
+    enabled_radio = @page.locator("input.spec--author-display-enabled-true")
+    assert enabled_radio.checked?
+
+    # Toggle to disabled
+    disabled_radio = @page.locator("input.spec--author-display-enabled-false")
+    disabled_radio.click
+
+    # Save settings
+    @page.click("input.spec--save-button")
+    @page.wait_for_selector("div.notice")
+
+    # Verify setting was saved
+    assert_equal "false", SiteSetting.get("author_display_enabled")
+  end
+
+  test "author info is not displayed when setting is disabled" do
+    # Disable author display
+    SiteSetting.set("author_display_enabled", "false")
+    
+    # Visit homepage
+    @page.goto("http://localhost:#{@server_port}/")
+    
+    # Author info should not be displayed
+    author_elements = @page.locator(".spec--article-author")
+    assert_equal 0, author_elements.count
+  end
+
+  test "author info is displayed when setting is enabled" do
+    # Enable author display
+    SiteSetting.set("author_display_enabled", "true")
+    
+    # Visit homepage
+    @page.goto("http://localhost:#{@server_port}/")
+    
+    # Author info should be displayed
+    author_elements = @page.locator(".spec--article-author")
+    assert author_elements.count > 0
+  end
+
+  test "author info on article detail page respects setting" do
+    # Enable author display first
+    SiteSetting.set("author_display_enabled", "true")
+    
+    # Visit article detail page
+    @page.goto("http://localhost:#{@server_port}/articles/#{@article1.id}")
+    
+    # Author info should be displayed
+    author_element = @page.locator(".spec--article-author")
+    assert author_element.count > 0
+    
+    # Disable author display
+    SiteSetting.set("author_display_enabled", "false")
+    
+    # Refresh page
+    @page.reload
+    
+    # Author info should not be displayed
+    author_element = @page.locator(".spec--article-author")
+    assert_equal 0, author_element.count
+  end
+
+  test "site settings form shows correct default value" do
+    login_as_admin
+
+    # Test with enabled setting
+    SiteSetting.set("author_display_enabled", "true")
+    @page.goto("http://localhost:#{@server_port}/admin/site-settings")
+    @page.wait_for_selector("h1:has-text('サイト設定')")
+
+    enabled_radio = @page.locator("input.spec--author-display-enabled-true")
+    assert enabled_radio.checked?
+
+    # Test with disabled setting
+    SiteSetting.set("author_display_enabled", "false")
+    @page.goto("http://localhost:#{@server_port}/admin/site-settings")
+    @page.wait_for_selector("h1:has-text('サイト設定')")
+
+    disabled_radio = @page.locator("input.spec--author-display-enabled-false")
+    assert disabled_radio.checked?
+  end
+end


### PR DESCRIPTION
- Add author_display_enabled field to SiteSetting model
- Update site settings form to include author display toggle
- Modify show_author_info? helper to check site setting in addition to multiple authors
- Add comprehensive tests for author display toggle functionality
- Update article detail page to include CSS class for author display testing

Features:
- Admin can enable/disable author display from site settings
- Author info is only shown when both setting is enabled AND multiple authors exist
- Changes apply to article index, archive pages, and article detail pages

🤖 Generated with [Claude Code](https://claude.ai/code)