### PR TITLE
Fix N+1 query problems in admin and articles controllers

### DIFF
--- a/app/controllers/admin/admins_controller.rb
+++ b/app/controllers/admin/admins_controller.rb
@@ -2,7 +2,7 @@ class Admin::AdminsController < Admin::BaseController
   before_action :set_admin, only: [:show, :destroy]
 
   def index
-    @admins = Admin.all.order(:user_id)
+    @admins = Admin.includes(:articles).order(:user_id)
   end
 
   def show
@@ -44,7 +44,7 @@ class Admin::AdminsController < Admin::BaseController
   end
 
   def confirm_delete
-    @admin = Admin.find(params[:id])
+    @admin = Admin.includes(:articles).find(params[:id])
     
     if @admin.last_admin?
       redirect_to admin_admins_path, alert: "最後の管理者は削除できません。"
@@ -56,7 +56,7 @@ class Admin::AdminsController < Admin::BaseController
   end
 
   def process_delete
-    @admin = Admin.find(params[:id])
+    @admin = Admin.includes(:articles).find(params[:id])
     action_type = params[:action_type]
     
     case action_type
@@ -85,7 +85,7 @@ class Admin::AdminsController < Admin::BaseController
   private
 
   def set_admin
-    @admin = Admin.find(params[:id])
+    @admin = Admin.includes(:articles).find(params[:id])
   end
 
   def admin_params

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -3,6 +3,7 @@ class ArticlesController < ApplicationController
 
   def index
     @articles = Article.published.order(created_at: :desc).page(params[:page])
+    @show_author_info = calculate_show_author_info
   end
 
   def show
@@ -18,6 +19,7 @@ class ArticlesController < ApplicationController
     @monthly_counts = Article.published.where("strftime('%Y', created_at) = ?", @year.to_s)
                             .group("strftime('%m', created_at)")
                             .count
+    @show_author_info = calculate_show_author_info
   end
 
   def archive_month
@@ -27,6 +29,7 @@ class ArticlesController < ApplicationController
                              @year.to_s, sprintf("%02d", @month))
                       .order(created_at: :desc)
                       .page(params[:page])
+    @show_author_info = calculate_show_author_info
   end
 
   def feed
@@ -41,5 +44,9 @@ class ArticlesController < ApplicationController
 
   def set_article
     @article = Article.find(params[:id])
+  end
+
+  def calculate_show_author_info
+    @_show_author_info ||= SiteSetting.author_display_enabled && Article.published.select(:author).distinct.count >= 2
   end
 end


### PR DESCRIPTION
- Add includes(:articles) to all Admin queries in AdminsController to prevent N+1 when displaying article counts
- Add calculate_show_author_info method to ArticlesController to prevent repeated author count queries
- Memoize show_author_info calculation to avoid database hits on each view render
- All tests pass with optimizations in place

🤖 Generated with [Claude Code](https://claude.ai/code)