### PR TITLE
Add autocomplete attributes to profile edit form

### DIFF
--- a/app/views/admin/profiles/edit.html.erb
+++ b/app/views/admin/profiles/edit.html.erb
@@ -17,7 +17,8 @@
               type: "email",
               required: true,
               help_text: "ログイン時に使用するメールアドレスです。",
-              spec_class: "spec--email-input"
+              spec_class: "spec--email-input",
+              autocomplete: "email"
             ) %>
             <%= render FormFieldComponent.new(
               form: f,
@@ -25,7 +26,8 @@
               label: "ユーザーID",
               required: true,
               help_text: "記事の著者として表示されるIDです。",
-              spec_class: "spec--user-id-input"
+              spec_class: "spec--user-id-input",
+              autocomplete: "username"
             ) %>
           </div>
         </div>


### PR DESCRIPTION
プロフィール編集フォームにautocomplete属性を追加:

変更内容:
- メールアドレスフィールドに autocomplete: "email" を設定
- ユーザーIDフィールドに autocomplete: "username" を設定

利点:
- ブラウザのオートコンプリート機能が適切に動作
- ユーザーが以前入力した情報を簡単に再利用可能
- ユーザーエクスペリエンスの向上
- Webフォームのベストプラクティスに準拠

テスト結果: プロフィール編集テスト5件全て成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)