### PR TITLE
fix: デプロイ前にkamal-proxyを最新版に更新

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,9 @@ jobs:
       run: |
         kamal lock release || echo "No existing lock to release"
 
+    - name: Update kamal-proxy
+      run: kamal proxy reboot -y
+
     - name: Deploy with Kamal
       run: kamal deploy
 


### PR DESCRIPTION
## 概要

kamal-proxy が v0.9.0 と古く、v0.9.2 以上が必要なためデプロイが失敗していた問題を修正。

## 原因

```
ERROR: kamal-proxy version v0.9.0 is too old,
run `kamal proxy reboot` in order to update to at least v0.9.2
```

## 対応

デプロイステップの直前に `kamal proxy reboot -y` を実行するステップを追加。

## 注意

proxy の更新が完了したら、このステップは削除して問題ありません（毎回実行すると brief outage が発生するため）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * デプロイメント実行時のプロセス制御を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->