### PR TITLE
本番のOOM再発防止: jemalloc・メモリ上限・監視/自己修復・Runbook

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,11 @@ bundle exec rails test test/lib/tailwind_config_test.rb  # パス検証テスト
 - CSSが再ビルドされない場合は `bin/rails assets:clobber && bin/dev` を実行してキャッシュをクリアします。
 - バグ修正時は必ず再発防止テストを追加し、タスクはメモ化して誰でも途中から再開できる状態を保ちます。
 
+## 運用・本番（Kamal）
+- 本番は Kamal で 1GB の VPS にデプロイ。障害対応・再発防止の手順は `docs/operations.md`（Runbook）に集約し、構成や運用ルールを変えたら必ず更新する。
+- 502（kamal-proxy生存・アプリ停止）時は Runbook の復旧手順に従う。OOM が疑わしいときは `docker inspect` の `OOMKilled`/`ExitCode` と `free -h` を確認する。
+- 監視＋自己修復は `ops/health-check.sh`（サーバ上で cron 実行）。本番のメモリ設定（swap・コンテナ上限・jemalloc）を変更したら Runbook に反映する。
+
 ## ドキュメント & ライセンス
 - 本リポジトリは [MIT License](LICENSE) で公開されています。コードや依存を追加するときはライセンス互換性を確認してください。
 - README と `AGENTS.md` / `CLAUDE.md` は常に最新状態を保持し、仕様変更やルール追加があれば3ファイルすべてを同一コミットで更新してください。

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,6 +74,12 @@ RUN echo "=== Node.js built TailwindCSS info ===" && ls -la app/assets/builds/ta
 # Final stage for app image
 FROM base
 
+# Activate jemalloc to reduce Ruby's memory footprint and fragmentation.
+# libjemalloc2 is installed in the base stage but is inert without LD_PRELOAD.
+# narenas:2 / dirty_decay_ms keep RSS low on the 1GB production VPS (see docs/operations.md).
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2" \
+    MALLOC_CONF="dirty_decay_ms:1000,narenas:2,background_thread:true"
+
 # Copy built artifacts: gems, application
 COPY --from=build "${BUNDLE_PATH}" "${BUNDLE_PATH}"
 COPY --from=build /rails /rails

--- a/README.md
+++ b/README.md
@@ -206,6 +206,13 @@ bundle exec rails test:system
 - **システムテスト**: E2E全体フロー（Playwright）
 - **セキュリティテスト**: ロボットヘッダー、認証機能
 
+## 運用・本番デプロイ
+
+本番環境へのデプロイは Kamal を使用します。本番の障害対応（502復旧）・再発防止策（スワップ、監視＋自己修復、メモリ上限、jemalloc）は運用 Runbook にまとめています。
+
+- 運用 Runbook: [`docs/operations.md`](docs/operations.md)
+- 監視＋自己修復スクリプト: [`ops/health-check.sh`](ops/health-check.sh)（サーバ上で cron 実行）
+
 ## セキュリティ
 
 ### 管理画面の保護

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -7,7 +7,14 @@ image: machida/mb
 # Deploy to these servers.
 servers:
   web:
-    - 153.121.42.228
+    hosts:
+      - 153.121.42.228
+    # Cap the app container's RAM so a memory spike spills into swap and is
+    # contained to the container instead of OOM-killing the whole 1GB host.
+    # Requires host swap to be enabled first (see docs/operations.md). Tune as needed.
+    options:
+      memory: 768m
+      memory-swap: 2g
   # job:
   #   hosts:
   #     - 192.168.0.1

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -1,0 +1,85 @@
+# 運用 Runbook（本番）
+
+本番は Kamal で 1台の VPS にデプロイしています。本書は障害対応・再発防止のための手順をまとめたものです。
+
+## 構成サマリ
+- ホスト: さくらVPS `153.121.42.228`（ドメイン `mxchida.com`）／ RAM 約1GB
+- 接続: SSH `ubuntu` ユーザ（root直ログイン不可）。鍵はローカルの `~/.ssh/id_rsa`
+  ```bash
+  ssh -i ~/.ssh/id_rsa ubuntu@153.121.42.228
+  ```
+- 構成: `kamal-proxy`（SSL終端・80/443）→ アプリコンテナ `mb-web-<sha>`（Thruster:80 → Puma:3000）
+- ジョブ: `SOLID_QUEUE_IN_PUMA=true` のため SolidQueue は web と同じコンテナで稼働
+- ヘルスチェック: `/up`（Kamal proxy が10秒間隔、Docker HEALTHCHECK も併用）
+
+## 502 が出たときの復旧手順
+502 は「kamal-proxy は生きているがアプリコンテナがダウン」を意味します。
+
+```bash
+ssh -i ~/.ssh/id_rsa ubuntu@153.121.42.228
+
+# 1. 状態確認（OOMKilled / ExitCode を見る）
+docker ps -a --format '{{.Names}}\t{{.Status}}' | grep -E 'mb-web|proxy'
+docker inspect <mb-web-コンテナ名> \
+  --format 'OOMKilled={{.State.OOMKilled}} ExitCode={{.State.ExitCode}} FinishedAt={{.State.FinishedAt}}'
+
+# 2. 不要な孤児/古いコンテナを掃除（メモリ解放）
+docker ps -a --format '{{.Names}}\t{{.Status}}' | grep mb-web   # 確認してから
+docker rm <停止中の不要コンテナ>
+
+# 3. 現行コンテナを起動（最新のものが docker ps -a の先頭）
+docker start <mb-web-コンテナ名>
+
+# 4. 検証（内部 → 外部の順で200を確認）
+docker exec <mb-web-コンテナ名> curl -s -o /dev/null -w '%{http_code}\n' http://localhost/up
+curl -s -o /dev/null -w '%{http_code}\n' https://mxchida.com/up
+```
+
+正規にやり直す場合はローカルから `bin/kamal deploy`。
+
+## 再発防止チェックリスト
+
+### 1. スワップ（最優先・OOM根本緩和）
+1GB・スワップ無しのため OOM が起きやすい。2GBのスワップを追加する:
+```bash
+sudo fallocate -l 2G /swapfile
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+echo '/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab
+echo 'vm.swappiness=10' | sudo tee /etc/sysctl.d/99-swap.conf
+sudo sysctl -w vm.swappiness=10
+free -h   # Swap 行が 2.0Gi になっていれば成功
+```
+
+### 2. 監視＋自己修復（落ちても即気づく・自動復旧）
+`ops/health-check.sh` をサーバに導入し cron で1分毎に実行する。ダウン時に自動で `docker start` を試み、Webhook（Discord/Slack互換）に通知する。
+```bash
+# サーバ上（ubuntu）で
+sudo install -m 755 ops/health-check.sh /usr/local/bin/mb-health-check
+sudo tee /etc/default/mb-health-check >/dev/null <<'EOF'
+HEALTHCHECK_URL=http://localhost/up
+HEALTHCHECK_WEBHOOK_URL=        # 任意: Discord/Slack の incoming webhook URL
+EOF
+( crontab -l 2>/dev/null; echo '* * * * * /usr/local/bin/mb-health-check >> /var/log/mb-health-check.log 2>&1' ) | crontab -
+```
+加えて、外形監視（UptimeRobot / Better Stack 等の無料枠）で `https://mxchida.com/up` を外部からも監視するとサーバ自体の停止にも気づける。
+
+### 3. コンテナのメモリ上限（巻き添えOOM防止）
+`config/deploy.yml` の `servers.web.options` で `memory: 768m` / `memory-swap: 2g` を設定済み。**スワップ追加後**に `bin/kamal deploy` で反映される。実メモリ使用に応じて数値を調整する。
+
+### 4. jemalloc（RubyのRSS削減）
+`Dockerfile` で `LD_PRELOAD` により jemalloc を有効化済み（`MALLOC_CONF=dirty_decay_ms:1000,narenas:2,background_thread:true`）。次回ビルド・デプロイで反映。
+
+### 5. 中期対応
+- VPS の RAM を 2GB 以上へ増強（最も確実な根本解）
+- 余裕が出たら SolidQueue を web コンテナから分離（`SOLID_QUEUE_IN_PUMA` を外し別プロセス/コンテナへ）
+
+## メモリ状況の確認
+```bash
+free -h
+docker stats --no-stream
+```
+
+## 障害履歴
+- 2026-06-09: アプリコンテナが OOMKilled（ExitCode 137）。restart policy が `unless-stopped` でも再起動に失敗し、監視・アラートが無かったため約2週間ダウン（502）。本 Runbook 整備のきっかけ。

--- a/ops/health-check.sh
+++ b/ops/health-check.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Production health monitor + self-heal for the Kamal-deployed app.
+#
+# Runs ON THE SERVER via cron. It checks the local /up endpoint and, if the app
+# is down, attempts to restart the current container and sends a notification.
+# This closes the gap that caused the 2026-06 outage: after an OOM kill the
+# container failed to auto-restart and nobody was alerted for two weeks.
+#
+# Install (on the server, as the ubuntu user):
+#   sudo install -m 755 health-check.sh /usr/local/bin/mb-health-check
+#   sudo tee /etc/default/mb-health-check >/dev/null <<'EOF'
+#   HEALTHCHECK_URL=http://localhost/up
+#   HEALTHCHECK_WEBHOOK_URL=        # optional: Discord/Slack-compatible incoming webhook
+#   EOF
+#   ( crontab -l 2>/dev/null; echo '* * * * * /usr/local/bin/mb-health-check >> /var/log/mb-health-check.log 2>&1' ) | crontab -
+#
+# See docs/operations.md for the full runbook.
+
+set -uo pipefail
+
+# Load optional config (URL + webhook) if present.
+[ -f /etc/default/mb-health-check ] && . /etc/default/mb-health-check
+
+HEALTHCHECK_URL="${HEALTHCHECK_URL:-http://localhost/up}"
+HEALTHCHECK_WEBHOOK_URL="${HEALTHCHECK_WEBHOOK_URL:-}"
+CONTAINER_PREFIX="${CONTAINER_PREFIX:-mb-web-}"
+
+log() { echo "[$(date -u '+%Y-%m-%dT%H:%M:%SZ')] $*"; }
+
+notify() {
+  local msg="$1"
+  log "NOTIFY: ${msg}"
+  [ -z "${HEALTHCHECK_WEBHOOK_URL}" ] && return 0
+  # "content" is read by Discord, "text" by Slack; other services ignore extras.
+  curl -fsS -m 10 -H 'Content-Type: application/json' \
+    -d "{\"content\":\"[mb] ${msg}\",\"text\":\"[mb] ${msg}\"}" \
+    "${HEALTHCHECK_WEBHOOK_URL}" >/dev/null 2>&1 \
+    || log "WARN: webhook notification failed"
+}
+
+# Newest app container (docker lists newest first).
+current_container() {
+  docker ps -a --filter "name=${CONTAINER_PREFIX}" --format '{{.Names}}' | head -1
+}
+
+probe() {
+  curl -fsS -o /dev/null -m 10 "${HEALTHCHECK_URL}"
+}
+
+if probe; then
+  # Healthy: opportunistically clean up stray stopped app containers beyond the
+  # most recent few so leftovers can't silently eat RAM (see the 2026-06 orphan).
+  docker ps -a --filter "name=${CONTAINER_PREFIX}" --filter status=exited \
+    --format '{{.Names}}' | tail -n +6 | xargs -r docker rm >/dev/null 2>&1
+  exit 0
+fi
+
+log "DOWN: ${HEALTHCHECK_URL} did not return success"
+
+container="$(current_container)"
+if [ -z "${container}" ]; then
+  notify "site DOWN and no ${CONTAINER_PREFIX}* container found — manual intervention needed"
+  exit 1
+fi
+
+log "Attempting to start container: ${container}"
+docker start "${container}" >/dev/null 2>&1
+
+# Give Thruster/Puma time to boot before re-probing.
+for i in $(seq 1 12); do
+  sleep 5
+  if probe; then
+    notify "site was DOWN, auto-restarted ${container} — now healthy"
+    log "RECOVERED after restart"
+    exit 0
+  fi
+done
+
+notify "site DOWN — auto-restart of ${container} FAILED, manual intervention needed"
+log "FAILED to recover"
+exit 1


### PR DESCRIPTION
## 背景
本番（Kamal / 1GB VPS / `mxchida.com`）でアプリコンテナが **OOM kill（ExitCode 137）** され、`restart policy: unless-stopped` でも再起動に失敗、外形監視も無かったため **約2週間 502 のままダウン**していた。本PRはその再発防止策一式。

## 変更内容
- **jemalloc 有効化**（`Dockerfile`）: インストール済みだが未使用だった jemalloc を `LD_PRELOAD` で有効化。`MALLOC_CONF`（narenas:2 / dirty_decay_ms）で Ruby の RSS とフラグメンテーションを削減。
- **コンテナメモリ上限**（`config/deploy.yml`）: `memory: 768m` / `memory-swap: 2g`。スパイクを swap へ逃がしてホスト全体の巻き添え OOM を防止（**ホスト swap が前提**）。
- **監視＋自己修復**（`ops/health-check.sh`）: サーバ cron で `/up` を監視 → ダウン時に `docker start` で自動復旧 → Webhook（Discord/Slack 互換）通知。健全時には古い孤児コンテナを自動掃除。
- **運用 Runbook**（`docs/operations.md`）: 502 復旧手順・swap 設定・監視導入・障害履歴を集約。`README` / `CLAUDE.md`(=`AGENTS.md`) から参照を追加。

## デプロイ前に必要な手動作業（サーバ側）
1. **swap 2GB を追加**（最優先。`docs/operations.md` 参照）。メモリ上限・memory-swap はこれが前提。
2. `ops/health-check.sh` をサーバへ install＋cron 登録し、通知 Webhook を設定。
3. swap 追加後に `bin/kamal deploy` で jemalloc・メモリ上限を反映。
4. （任意）UptimeRobot 等で `mxchida.com/up` を外形監視。

## 実行済みコマンド
- `ruby -ryaml`（deploy.yml の YAML 妥当性）✅
- `bash -n ops/health-check.sh`（構文）✅
- `npm run lint`（アプリコードに警告なし／vendor のみ既存ノイズ）✅
- ※アプリの Ruby/JS コードは未変更のため `rails test:all`（Playwright含む）は対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)